### PR TITLE
Extend middle container to screen height in milan.html

### DIFF
--- a/style-milan.css
+++ b/style-milan.css
@@ -54,8 +54,7 @@ body {
 }
 
 .content {
-    height: auto;
-    max-height: 400px;
+    height: 100vh;
     overflow-y: auto;
     width: 100%;
     max-width: 600px;


### PR DESCRIPTION
Extend the middle container in `milan.html` to screen height.

* Set the height of the `.content` class to `100vh` in `style-milan.css`
* Ensure the `.content` class has `overflow-y: auto` to allow scrolling if content exceeds screen height

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/urukalo/urukalo.github.io?shareId=84eb8fff-7c41-46c6-958f-18bb4355403f).